### PR TITLE
Add `as const` to Analytics type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -363,7 +363,7 @@ export default async function BuildTypes(
     ${Object.entries(state.analytics)
       .map(([js, str]) => `  [Nav.${js}]: ${str === false ? 'false' : JSON.stringify(str)},`)
       .join('\n')}
-  };
+  } as const;
 
   // Screen parameter types
   ${state.parameterLists

--- a/tests/snapshots/navStack.ts
+++ b/tests/snapshots/navStack.ts
@@ -56,7 +56,7 @@ export const Analytics = {
   [Nav.FirstTimeUserExperience.$name]: 'FIRST_TIME_UX',
   [Nav.FirstTimeUserExperience.Login]: 'Login_Start',
   [Nav.App.Main.FindGas.$name]: false,
-};
+} as const;
 
 // Screen parameter types
 export interface LoginRegisterParams extends FlexiblePresentationFlow {


### PR DESCRIPTION
This adds `as const` to the Analytics config generated in order to get the same type narrowing as the `Nav` config export.

Also updates test snapshot to match new changes.